### PR TITLE
chore: workflow clone OI-wiki repo depth 1

### DIFF
--- a/.github/workflows/auto-release-typst.yml
+++ b/.github/workflows/auto-release-typst.yml
@@ -38,7 +38,7 @@ jobs:
           sudo mv lxgw-wenkai-v1.312 /usr/share/fonts/
           fc-cache
           
-          git clone https://github.com/OI-wiki/OI-wiki.git
+          git clone https://github.com/OI-wiki/OI-wiki.git --depth=1
           cd remark-typst
           npm install
           cd ..

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -57,7 +57,7 @@ jobs:
             cd ..
             cd oi-wiki-export
             npm i
-            git clone https://github.com/OI-wiki/OI-wiki.git
+            git clone https://github.com/OI-wiki/OI-wiki.git --depth=1
             python3 increase-mem-limit.py
             fmtutil-sys --all
             node index.js ./OI-wiki

--- a/.github/workflows/test-build-typst.yml
+++ b/.github/workflows/test-build-typst.yml
@@ -39,7 +39,7 @@ jobs:
           sudo mv lxgw-wenkai-v1.312 /usr/share/fonts/
           fc-cache
           
-          git clone https://github.com/OI-wiki/OI-wiki.git
+          git clone https://github.com/OI-wiki/OI-wiki.git --depth=1
           cd remark-typst
           npm install
           cd ..

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -56,7 +56,7 @@ jobs:
             cd ..
             cd oi-wiki-export
             npm i
-            git clone https://github.com/OI-wiki/OI-wiki.git
+            git clone https://github.com/OI-wiki/OI-wiki.git --depth=1
             python3 increase-mem-limit.py
             fmtutil-sys --all
             node index.js ./OI-wiki


### PR DESCRIPTION
help to make clone OI-wiki repo fast,and less temp storage.

some perf data:
du -sh *
80M     depth=1
137M    full
full:
remote: Enumerating objects: 64556, done.
remote: Counting objects: 100% (1046/1046), done.
remote: Compressing objects: 100% (148/148), done.
remote: Total 64556 (delta 483), reused 989 (delta 461), pack-reused 63510
接收对象中: 100% (64556/64556), 86.66 MiB | 19.96 MiB/s, 完成.
处理 delta 中: 100% (47016/47016), 完成.
正在更新文件: 100% (2189/2189), 完成.

real    0m8.226s
user    0m3.234s
sys     0m2.344s
depth=1:
remote: Enumerating objects: 2546, done.
remote: Counting objects: 100% (2546/2546), done.
remote: Compressing objects: 100% (1817/1817), done.
remote: Total 2546 (delta 347), reused 1806 (delta 341), pack-reused 0
接收对象中: 100% (2546/2546), 31.35 MiB | 16.27 MiB/s, 完成.
处理 delta 中: 100% (347/347), 完成.
正在更新文件: 100% (2189/2189), 完成.

real    0m5.877s
user    0m0.609s
sys     0m1.625s
