### PR TITLE
chore(ci): use upstream action and lock docker version

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,8 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build the LaTeX document
-        uses: OI-wiki/latex-action@v1.0.0
+        uses: xu-cheng/latex-action@v3
         with:
+          docker_image: ghcr.io/xu-cheng/texlive-full:20220801
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
           args: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode -8bit"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build the LaTeX document
-        uses: OI-wiki/latex-action@v1.0.0
+        uses: xu-cheng/latex-action@v3
         with:
+          docker_image: ghcr.io/xu-cheng/texlive-full:20220801
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
           args: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode -8bit"


### PR DESCRIPTION
如果镜像用最新的话会报错，所以和 OI-Wiki/latex-action 一样将 `docker_image` 锁在 `20220801` 了。