### PR TITLE
feat(latex): use the latest docker image

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,10 +17,9 @@ jobs:
       - name: Build the LaTeX document
         uses: xu-cheng/latex-action@v3
         with:
-          docker_image: ghcr.io/xu-cheng/texlive-full:20220801
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
-          args: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode -8bit"
+          args: "-pdf -file-line-error -halt-on-error -interaction=batchmode -8bit"
           extra_system_packages: |
             unzip
             wget
@@ -34,9 +33,9 @@ jobs:
             git
             python3
             py3-pygments
-            inkscape
             libxml2
             openssh
+            sqlite-dev
           pre_compile: |
             umask 0 && npm config set cache /tmp/.npm
             wget -q -O notosans.zip "https://noto-website-2.storage.googleapis.com/pkgs/NotoSans-hinted.zip"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Build the LaTeX document
         uses: xu-cheng/latex-action@v3
         with:
-          docker_image: ghcr.io/xu-cheng/texlive-full:20220801
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
-          args: "-pdf -file-line-error -halt-on-error -interaction=nonstopmode -8bit"
+          args: "-pdf -file-line-error -halt-on-error -interaction=batchmode -8bit"
           extra_system_packages: |
             unzip
             wget
@@ -33,9 +32,9 @@ jobs:
             git
             python3
             py3-pygments
-            inkscape
             libxml2
             openssh
+            sqlite-dev
           pre_compile: |
             umask 0 && npm config set cache /tmp/.npm
             wget -q -O notosans.zip "https://noto-website-2.storage.googleapis.com/pkgs/NotoSans-hinted.zip"

--- a/oi-wiki-export/oi-wiki-export.tex
+++ b/oi-wiki-export/oi-wiki-export.tex
@@ -58,6 +58,27 @@
 \usepackage{hyperref}
 \hypersetup{colorlinks,urlcolor=.,breaklinks=true,hyperfootnotes=true,unicode}
 
+\usepackage{xpatch}
+\ExplSyntaxOn
+% apply the patch only if package date is at least 2022-08-05 _and_
+% earlier than 2022-08-31
+% bug was introduced in v3.9.1 (2022-08-15) and fixed in dev on 2022-08-31
+% see
+% https://github.com/CTeX-org/ctex-kit/commit/a841dabaac7c2dccacd1858ba96f6eb38adfb335
+% https://github.com/CTeX-org/ctex-kit/commit/aa5f00db05f12034845f8e5c4119971b5aae33ff
+% https://github.com/CTeX-org/ctex-kit/issues/636
+% TODO: Test and remove this when xeCJK v3.9.2 avaliable
+\IfPackageAtLeastTF{xeCJK}{2022-08-05}{
+  \IfPackageAtLeastTF{xeCJK}{2022-08-31}{}{
+    \xpatchcmd \__xeCJK_check_for_xglue:
+      {\__xeCJK_if_last_glue:TF}
+      {\__xeCJK_if_last_glue:T}
+      {}{\PatchFailed}
+  }
+}{}
+\ExplSyntaxOff
+
+
 % additional CJK characters for '←' and '→'
 \xeCJKsetcharclass{"2190}{"2192}{1}% 1: CJK
 \xeCJKsetup{xCJKecglue}

--- a/remark-latex/lib/compiler.js
+++ b/remark-latex/lib/compiler.js
@@ -296,23 +296,30 @@ export default function compiler(options) {
             if (existsSync(uri.replace(/\.svg$/, ".printable.svg"))) {
               console.log(`[SVG] Detected printable version of ${uri}`);
               if (!existsSync(dest)) {
-                execFileSync("inkscape", [
-                  `--export-filename=${dest}`,
+                execFileSync("magick", [
                   uri.replace(/\.svg$/, ".printable.svg"),
+                  "-background",
+                  "white",
+                  dest,
                 ]);
               }
             } else if (!existsSync(dest)) {
-              execFileSync("inkscape", [`--export-filename=${dest}`, uri]);
+              execFileSync("magick", [
+                uri,
+                "-background",
+                "white",
+                dest,
+              ]);
             }
           }
           default: {
             if (!existsSync(dest)) {
               // 混合白色背景（原图可能是 PNG 透明图）
-              execFileSync("convert", [
+              execFileSync("magick", [
+                ext === ".gif" ? uri + "[0]" : uri,
                 "-background",
                 "white",
                 "-flatten",
-                ext === ".gif" ? uri + "[0]" : uri,
                 dest,
               ]);
             }


### PR DESCRIPTION
主要将用到的 TeXLive 版本更新到 `latest`，附加的修改：

- 最新的 TeXLive 中 xeCJK 版本有 bug，patch 位于 dev 但未发版，根据 https://github.com/CTeX-org/ctex-kit/issues/636 进行 patch
- 移除 inkspace 依赖，全部使用 magick，并根据[文档](https://imagemagick.org/script/magick.php)修改参数传递方式
- 使用 `batchmode` 替代 `nonstopmode` 减少日志输出
- 添加必要依赖 `sqlite-dev`，不添加的话会报错 https://github.com/HeRaNO/OI-Wiki-export/actions/runs/13221204991/job/36911601695#step:3:239