### PR TITLE
fix(typst): use image instead of image.decode

### DIFF
--- a/oi-wiki-export-typst/oi-wiki-export.typ
+++ b/oi-wiki-export-typst/oi-wiki-export.typ
@@ -28,8 +28,8 @@
 
 #align(center + horizon)[
   // OI-Wiki logo
-  #image.decode(
-    "<svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M12 3 1 9l11 6 9-4.91V17h2V9M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82Z\"></path></svg>",
+  #image(
+    bytes("<svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M12 3 1 9l11 6 9-4.91V17h2V9M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82Z\"></path></svg>"),
     height: 4cm,
   )
   #text(


### PR DESCRIPTION
#94 中漏改了这个地方，会在编译的时候报 warning