### PR TITLE
feat(*): allow internal link to point to customized anchors in a page

### DIFF
--- a/oi-wiki-export-typst/index.js
+++ b/oi-wiki-export-typst/index.js
@@ -105,7 +105,7 @@ async function main() {
       .use(remarkParse)
       .use(remarkMath)
       .use(remarkGfm)
-      .use(remarkDetails)
+      .use(remarkDetails, {normalize: true})
       .use(remarkTabbed)
       // .use(remarkTabbed)
       .use(remarkTypst, {

--- a/oi-wiki-export-typst/oi-wiki-export.typ
+++ b/oi-wiki-export-typst/oi-wiki-export.typ
@@ -181,20 +181,61 @@
 )
 #show enum: set block(width: 100%)
 
+#let get-section-numbering-from-label(label-str, location) = {
+  if not label-str.contains("-") { return none }
+  
+  let parts = label-str.split("-")
+  if parts.len() < 2 { return none }
+  
+  let section-label = parts.first()
+  let section-query = query(label(section-label))
+  
+  if section-query.len() > 0 {
+    let section-el = section-query.first()
+    if section-el.func() == heading and section-el.numbering != none {
+      // Return the section numbering, not the label
+      return numbering(
+        section-el.numbering,
+        ..counter(heading).at(section-el.location())
+      )
+    }
+  }
+  none
+}
+
 #show ref: it => {
   let el = it.element
-  if el != none and el.func() == heading and it.form == "normal" and it.supplement != auto {
-    link(
-      el.location(), 
-      it.supplement + text(size: 0.9em, "→" + numbering(
-        el.numbering,
-        ..counter(heading).at(el.location())
-      ) + "@p" + str(el.location().page()))
-    )
+  
+  if el != none and it.form == "normal" and it.supplement != auto {
+    // Case 1: Element has its own numbering (original behavior)
+    if el.func() == heading and el.numbering != none {
+      link(
+        el.location(), 
+        it.supplement + text(size: 0.9em, "→" + numbering(
+          el.numbering,
+          ..counter(heading).at(el.location())
+        ) + "@p" + str(el.location().page()))
+      )
+    }
+    // Case 2: Element doesn't have numbering, get section numbering from label
+    else {
+      let section-numbering = get-section-numbering-from-label(str(it.target), el.location())
+      
+      if section-numbering != none {
+        link(
+          el.location(),
+          it.supplement + text(size: 0.9em, "→" + section-numbering + "@p" + str(el.location().page()))
+        )
+      } else {
+        // Just return the original reference to keep program running
+        it
+      }
+    }
   } else {
     it
   }
 }
+
 #show ref: set text(fill: cmyk(0%, 100%, 100%, 0%))
 
 #show footnote.entry: it => {

--- a/oi-wiki-export-typst/package-lock.json
+++ b/oi-wiki-export-typst/package-lock.json
@@ -10,12 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "js-yaml": "^4.1.0",
-        "remark-details": "^4.1.1",
+        "remark-details": "github:c-forrest/remark-details#patch-refactor",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
         "remark-parse": "^10.0.1",
         "remark-tabbed": "^0.1.0",
-        "tiny-glob": "^0.2.9",
         "to-vfile": "^8.0.0",
         "unified": "^10.1.2",
         "unified-stream": "^3.0.0"
@@ -87,6 +86,24 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -181,16 +198,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
-    },
     "node_modules/hast": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hast/-/hast-1.0.0.tgz",
@@ -225,6 +232,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
@@ -245,6 +274,24 @@
       ],
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-plain-obj": {
@@ -1060,6 +1107,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/parse-entities": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
+      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/property-information": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.3.0.tgz",
@@ -1070,20 +1135,53 @@
       }
     },
     "node_modules/remark-details": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/remark-details/-/remark-details-4.1.1.tgz",
-      "integrity": "sha512-D/1LMFEVDILgiwMAVyBqLJ0cdTqzxkKeo2SrIrZrwv+zLO0cVPo/7WuXL4gxDzxdbUol0mNFvk2TA2g4QO8hvA==",
+      "version": "5.0.0",
+      "resolved": "git+ssh://git@github.com/c-forrest/remark-details.git#d33ff6dac710457ba7f98a178ca9b9cf86e2edcc",
+      "license": "MIT",
       "dependencies": {
         "hast": "^1.0.0",
         "hastscript": "^7.0.2",
         "mdast-util-from-markdown": "^1.0.2",
         "mdast-util-to-markdown": "^1.0.0",
+        "micromark-core-commonmark": "1.0.1",
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "unified": "^10.1.0",
         "unist-util-visit": "^4.1.0"
+      }
+    },
+    "node_modules/remark-details/node_modules/micromark-core-commonmark": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.1.tgz",
+      "integrity": "sha512-vEOw8hcQ3nwHkKKNIyP9wBi8M50zjNajtmI+cCUWcVfJS+v5/3WCh4PLKf7PPRZFUutjzl4ZjlHwBWUKfb/SkA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "parse-entities": "^3.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -1179,15 +1277,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
-      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
       }
     },
     "node_modules/to-vfile": {

--- a/oi-wiki-export-typst/package.json
+++ b/oi-wiki-export-typst/package.json
@@ -10,11 +10,11 @@
   "license": "ISC",
   "dependencies": {
     "js-yaml": "^4.1.0",
-    "remark-details": "^4.1.1",
-    "remark-tabbed": "^0.1.0",
+    "remark-details": "github:c-forrest/remark-details#patch-refactor",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "remark-parse": "^10.0.1",
+    "remark-tabbed": "^0.1.0",
     "to-vfile": "^8.0.0",
     "unified": "^10.1.2",
     "unified-stream": "^3.0.0"

--- a/oi-wiki-export/index.js
+++ b/oi-wiki-export/index.js
@@ -101,7 +101,7 @@ async function main() {
       .use(remarkParse)
       .use(remarkMath)
       .use(remarkGfm)
-      .use(remarkDetails)
+      .use(remarkDetails, {normalize: true})
       .use(remarkTabbed)
       .use(remarkFootnotes)
       .use(latex, {

--- a/oi-wiki-export/package-lock.json
+++ b/oi-wiki-export/package-lock.json
@@ -13,7 +13,7 @@
         "js-yaml": "^4.1.0",
         "node-fetch": "^3.3.2",
         "rehype-stringify": "^8.0.0",
-        "remark-details": "^4.1.1",
+        "remark-details": "github:c-forrest/remark-details#patch-refactor",
         "remark-footnotes": "^4.0.1",
         "remark-gfm": "^3.0.1",
         "remark-latex": "file:../remark-latex",
@@ -21,7 +21,6 @@
         "remark-parse": "^10.0.1",
         "remark-rehype": "^7.0.0",
         "remark-tabbed": "^0.1.0",
-        "tiny-glob": "^0.2.9",
         "to-vfile": "^8.0.0",
         "trim": "^1.0.1",
         "unified": "^10.1.2",
@@ -32,6 +31,7 @@
       "version": "0.13.0",
       "dependencies": {
         "escape-latex": "^1.2.0",
+        "mdast-util-to-string": "^4.0.0",
         "remark-details": "^1.1.0",
         "remark-footnotes": "^1.0.0",
         "remark-math": "^1.0.5",
@@ -922,6 +922,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "1.0.8",
       "license": "MIT",
@@ -1044,14 +1053,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/globalyzer": {
-      "version": "0.1.0",
-      "license": "MIT"
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "license": "MIT"
-    },
     "node_modules/hast": {
       "version": "1.0.0",
       "license": "MIT"
@@ -1150,6 +1151,28 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "2.0.5",
       "funding": [
@@ -1169,6 +1192,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2112,6 +2153,33 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
+      "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/property-information": {
       "version": "5.6.0",
       "license": "MIT",
@@ -2135,19 +2203,53 @@
       }
     },
     "node_modules/remark-details": {
-      "version": "4.1.1",
+      "version": "5.0.0",
+      "resolved": "git+ssh://git@github.com/c-forrest/remark-details.git#d33ff6dac710457ba7f98a178ca9b9cf86e2edcc",
       "license": "MIT",
       "dependencies": {
         "hast": "^1.0.0",
         "hastscript": "^7.0.2",
         "mdast-util-from-markdown": "^1.0.2",
         "mdast-util-to-markdown": "^1.0.0",
+        "micromark-core-commonmark": "1.0.1",
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "unified": "^10.1.0",
         "unist-util-visit": "^4.1.0"
+      }
+    },
+    "node_modules/remark-details/node_modules/micromark-core-commonmark": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.1.tgz",
+      "integrity": "sha512-vEOw8hcQ3nwHkKKNIyP9wBi8M50zjNajtmI+cCUWcVfJS+v5/3WCh4PLKf7PPRZFUutjzl4ZjlHwBWUKfb/SkA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "parse-entities": "^3.0.0"
       }
     },
     "node_modules/remark-footnotes": {
@@ -2279,14 +2381,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/tiny-glob": {
-      "version": "0.2.9",
-      "license": "MIT",
-      "dependencies": {
-        "globalyzer": "0.1.0",
-        "globrex": "^0.1.2"
       }
     },
     "node_modules/to-vfile": {

--- a/oi-wiki-export/package.json
+++ b/oi-wiki-export/package.json
@@ -14,7 +14,7 @@
     "js-yaml": "^4.1.0",
     "node-fetch": "^3.3.2",
     "rehype-stringify": "^8.0.0",
-    "remark-details": "^4.1.1",
+    "remark-details": "github:c-forrest/remark-details#patch-refactor",
     "remark-footnotes": "^4.0.1",
     "remark-gfm": "^3.0.1",
     "remark-latex": "file:../remark-latex",

--- a/remark-latex/lib/compiler.js
+++ b/remark-latex/lib/compiler.js
@@ -6,6 +6,7 @@ import { existsSync, writeFileSync, copyFileSync } from "fs";
 import { URL } from "url";
 
 import { visit } from "unist-util-visit";
+import { toString } from 'mdast-util-to-string';
 import request from "sync-request";
 
 // Utilities
@@ -14,6 +15,7 @@ import {
   isInternalLink,
   toPrefix,
   joinRelative,
+  getLabelText,
   isUrl,
   isCjk,
   trailingLineFeed,
@@ -22,6 +24,8 @@ import {
   nonParagraphBegin,
   escapeTextCommand,
   getTextEstimatedLength,
+  unicodeToLabel,
+  mkdocsMaterialSlugify,
 } from "./util.js";
 
 // Escape reserved symbols
@@ -48,8 +52,13 @@ export default function compiler(options) {
   const identifiers = {}; // indices 的逆映射
   const footnoteRefs = {}; // 脚注被引用的次数，键-值：标识符-引用次数
   const footnoteRefId = {}; // 脚注当前被引用第几次，键-值：脚注序号-第几次引用
+  const slugs = new Set(); // 记录用掉的锚点标签
   let footnoteCount = 0; // 脚注数量
   let inFootnote = false;
+
+  // 用于识别自定义锚点的正则表达式
+  // 要求字符串以 `<a ` 开始 `>` 结尾，且包含一个 `id` 字段，其中，`id` 字段必须以双引号包围
+  const anchorRegex = /^<a\b[^>]*\bid="([^"]+)"[^>]*>$/u; 
 
   parser.prototype.compile = wrapper;
   return parser;
@@ -197,6 +206,15 @@ export default function compiler(options) {
       }
       footnoteRefs[outLinkLable.get(location)]++;
     });
+
+    // 将小节标题配上锚点标签
+    visit(tree, 'heading', (node) => {
+      const headingText = toString(node);
+      const anchorId = mkdocsMaterialSlugify(headingText, slugs);
+      
+      node.data = node.data || {};
+      node.data.anchorId = anchorId;
+    });
   }
 
   function parse(node) {
@@ -210,9 +228,10 @@ export default function compiler(options) {
 
       if (isInternalLink(url)) {
         const location = toPrefix(joinRelative(url, options));
-        return location !== "" && raw !== ""
-          ? "\\linkwithpage{sect:{0}}{{1}}".format(location, children)
-          : "";
+        if (location === "" || raw === "") return "";
+        const labelID = getLabelText(url);
+        const label = labelID !== "" ? "{0}-{1}".format(location, unicodeToLabel(labelID)) : location;
+        return "\\linkwithpage{sect:{0}}{{1}}".format(label, children);
       } else {
         const location = escape(url);
         if (outLinkLable.has(location) === false || inFootnote) {
@@ -353,6 +372,9 @@ export default function compiler(options) {
         if (parText.startsWith("disqus:")) {
           return "";
         }
+        // The single-anchor paragraph should also start with a \par.
+        // Otherwise, the anchor will be placed at the end of the last paragraph.
+        // In latex, an empty line, even with an anchor, is invisible by default.
         return "\\par {0}".format(parText);
       }
       case "heading": {
@@ -365,7 +387,12 @@ export default function compiler(options) {
           "subparagraph",
         ];
         const depth = Math.min(options.depth + Math.max(node.depth, 2) - 2, 5);
-        return "\\{0}*{{1}}".format(block[depth], all(node, parse).join(""));
+        return "\\phantomsection\\{0}*{{1}}\\label{sect:{2}-{3}}".format(
+          block[depth], 
+          all(node, parse).join(""), 
+          options.prefix, 
+          unicodeToLabel(node.data.anchorId)
+        );
       }
       case "text": {
         if (options.forceEscape) {
@@ -466,6 +493,10 @@ export default function compiler(options) {
         return ""; // YAML front-matter，这里直接忽略
       }
       case "html": {
+        const labelID = node.value.trim().match(anchorRegex);
+        if (labelID) {
+          return "\\phantomsection\\label{sect:{0}-{1}}".format(options.prefix, unicodeToLabel(labelID[1]));
+        }
         return ""; // HTML 标签（不含标签里的内容，如 <kbd>A</kbd> 会分别产生一个 html('<kbd>'), text('A'), html('</kbd>')，这里直接忽略掉就行
       }
       case "link": {

--- a/remark-latex/lib/util.js
+++ b/remark-latex/lib/util.js
@@ -2,6 +2,7 @@
 
 import escape from "escape-latex";
 import { join } from "path";
+import crypto from 'crypto';
 
 // 对 node 的所有子结点执行 map(handler)
 export const all = function (node, handler) {
@@ -99,6 +100,7 @@ export function joinRelative(dir, options) {
   if (dir.indexOf("#") !== -1) {
     dir = dir.slice(0, dir.indexOf("#"));
   }
+  if (!dir) return options.path
   if (dir.startsWith("/")) {
     return join(options.root, dir.slice(1));
   } else if (dir.startsWith(".") && !dir.endsWith("md")) {
@@ -110,6 +112,14 @@ export function joinRelative(dir, options) {
     return join(options.path.split("/").slice(0, -2).join("/"), dir);
   }
 };
+
+// 获得 URL 中 # 后面的部分（用于内链索引）
+export function getLabelText(dir) {
+  if (dir.indexOf("#") !== -1) {
+    return dir.slice(dir.indexOf("#") + 1);
+  }
+  return "";
+}
 
 // 强制 LaTeX 在每个字符后都可换行（方式是在每个非 CJK 字符之间插入零宽间隔字符 Zero-Width Space）
 export function forceLinebreak(text) {
@@ -168,4 +178,37 @@ export function unquote(str) {
   } else {
     return str;
   }
+}
+
+// 将 Unicode 的标签转换为 ascii
+// 假设标签已经经过 slugify 处理，包含的 ascii 字符只有英语小写字母、hyphen 和下划线
+export function unicodeToLabel(str) {
+  const normalized = encodeURIComponent(str).replace(/%25/g, '%');
+  const hash = crypto.createHash('sha1').update(normalized, 'utf8').digest('hex');
+  return hash.slice(0, 16);
+}
+
+// 给小节标题转化为锚点标签并处理重复的问题
+export function mkdocsMaterialSlugify(text, existingSlugs = new Set()) {
+  // 参考 https://github.com/facelessuser/pymdown-extensions/blob/main/pymdownx/slugs.py
+  const slug = text
+    .normalize('NFC')
+    .trim()
+    .toLowerCase()
+    // 只保留数字、字母、重音符号、下划线、空格和 hyphen
+    .replace(/[^\p{L}\p{M}\p{N}_\- ]/gu, '')
+    // 将空格替换为 hyphen
+    .replace(/ /g, '-');
+
+  // 去重
+  let finalSlug = slug;
+  let counter = 1;
+  
+  while (existingSlugs.has(finalSlug)) {
+    finalSlug = `${slug}_${counter}`;
+    counter++;
+  }
+  
+  existingSlugs.add(finalSlug);
+  return finalSlug;
 }

--- a/remark-latex/package.json
+++ b/remark-latex/package.json
@@ -13,7 +13,8 @@
     "sync-request": "^6.1.0",
     "to-vfile": "^8.0.0",
     "unified": "^10.1.2",
-    "unist-util-visit": "^4.1.0"
+    "unist-util-visit": "^4.1.0",
+    "mdast-util-to-string": "^4.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/remark-typst/lib/compiler.js
+++ b/remark-typst/lib/compiler.js
@@ -6,12 +6,13 @@ import { existsSync, writeFileSync, copyFileSync } from 'fs'
 import { URL } from 'url'
 
 import { visit } from 'unist-util-visit'
+import { toString } from 'mdast-util-to-string'
 import request from 'sync-request'
 
 // Utilities
 import {
-  all, isInternalLink, toPrefix, joinRelative, isUrl, trailingLineFeed,
-  forceLinebreak, escapeAsString, checkCodeLang, capitalize, unquote
+  all, isInternalLink, toPrefix, joinRelative, getLabelText, isUrl, trailingLineFeed,
+  forceLinebreak, escapeAsString, checkCodeLang, capitalize, unquote, unicodeToLabel, mkdocsMaterialSlugify
 } from './util.js'
 // Escape reserved symbols
 import escape from '../escape-typst/src/index.js'
@@ -55,6 +56,8 @@ function toTypst(tree, options) {
   // that indentation should (not) be performed.
   const indentPar = new Array(true)
 
+  const slugs = new Set(); // 记录用掉的锚点标签
+
   // Index of current outer link
   let linkIndex = 0
   // Used to indicate whether the section named "References"
@@ -71,6 +74,10 @@ function toTypst(tree, options) {
   let isEscapingAsString = false
   // Whether we are in details block right now
   // let inDetails = false
+
+  // 用于识别自定义锚点的正则表达式
+  // 要求字符串以 `<a ` 开始 `>` 结尾，且包含一个 `id` 字段，其中，`id` 字段必须以双引号包围
+  const anchorRegex = /^<a\b[^>]*\bid="([^"]+)"[^>]*>$/u
 
   // Main procedure
   // 处理掉所有标签定义和链接跳转定义
@@ -104,15 +111,27 @@ function toTypst(tree, options) {
     visit(tree, 'definition', node => {
       mapDefinitions.set(node.identifier, node)
     })
+
+    // 将小节标题配上锚点标签
+    visit(tree, 'heading', (node) => {
+      const headingText = toString(node)
+      const anchorId = mkdocsMaterialSlugify(headingText, slugs)
+      
+      node.data = node.data || {}
+      node.data.anchorId = anchorId
+    })
   }
 
   function parse(node) {
     const makeLink = function (url) {
       if (isInternalLink(url)) {
         const location = toPrefix(joinRelative(url, options))
+        if (location === '') return ''
         const children = all(node, parse).join('')
+        const labelID = getLabelText(url)
+        const label = labelID !== "" ? "{0}-{1}".format(location, unicodeToLabel(labelID)) : location
         
-        return location !== '' ? '@{0}[{1}]'.format(location, children) : ''
+        return '@{0}[{1}]'.format(label, children)
       } else {
         const location = url.replace(/\\/g, '\\\\')
         ++linkIndex
@@ -205,6 +224,19 @@ function toTypst(tree, options) {
           return ''
         }
 
+        // The single-anchor paragraph should not start with an #h(2em).
+        // Otherwise, there will be an empty line in the PDF.
+        // It does not matter whether there is an empty line (in Typst) after this paragraph.
+        if (
+          node.children && node.children.length === 2
+          && node.children[0].type === "html"
+          && node.children[1].type === "html"
+          && anchorRegex.test(node.children[0].value.trim())
+          && node.children[1].value.trim() === "<\/a>"
+        ) {
+          return '{0}\n\n'.format(parText)
+        }
+
         if (indentPar.at(-1)) {
           return '#h(2em){0}\n\n'.format(parText)
         }
@@ -212,10 +244,11 @@ function toTypst(tree, options) {
       }
       case 'heading': {
         const depth = Math.min(options.depth + (node.depth - 1), 6)
-        return '#heading(level: {0}, numbering: none, outlined: false)[{1}]'.format(
+        const text = all(node, parse).join("")
+        return '#heading(level: {0}, numbering: none, outlined: false)[{1}] <{2}>'.format(
           depth,
-          all(node, parse).join(''),
-          options.nested ? '' : options.prefix)
+          text,
+          '{0}-{1}'.format(options.prefix, unicodeToLabel(node.data.anchorId)))
       }
       case 'text': {
         // NOTE: remove spaces between text objects?
@@ -287,6 +320,10 @@ function toTypst(tree, options) {
         } else if (node.value === '</kbd>') {
           isEscapingAsString = false
           return '")'
+        }
+        const labelID = node.value.trim().match(anchorRegex)
+        if (labelID) {
+          return '#place(dx: 0pt, dy: 0pt)[]#label("{0}-{1}")'.format(options.prefix, unicodeToLabel(labelID[1]))
         }
         return ''
       }

--- a/remark-typst/lib/util.js
+++ b/remark-typst/lib/util.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import { join } from 'path'
+import crypto from 'crypto'
 
 export function all(node, handler) {
   return node.children.map(handler)
@@ -50,7 +51,7 @@ export function joinRelative(url, options) {
   if (url.indexOf('#') !== -1) {
     url = url.slice(0, url.indexOf('#'))
   }
-
+  if (!url) return options.path
   // Join directories
   const isFolder = url.slice(url.lastIndexOf('.')).includes('/')
   if (url.startsWith('/')) {
@@ -64,6 +65,13 @@ export function joinRelative(url, options) {
   } else {
     return join(options.path.split('/').slice(0, -2).join('/'), url)
   }
+}
+
+export function getLabelText(dir) {
+  if (dir.indexOf("#") !== -1) {
+    return dir.slice(dir.indexOf("#") + 1);
+  }
+  return "";
 }
 
 export function forceLinebreak(text) {
@@ -120,4 +128,37 @@ export function unquote(str) {
   } else {
     return str
   }
+}
+
+// 将 Unicode 的标签转换为 ascii
+// 假设标签已经经过 slugify 处理，包含的 ascii 字符只有英语小写字母、hyphen 和下划线
+export function unicodeToLabel(str) {
+  const normalized = encodeURIComponent(str).replace(/%25/g, '%')
+  const hash = crypto.createHash('sha1').update(normalized, 'utf8').digest('hex')
+  return hash.slice(0, 16)
+}
+
+// 给小节标题转化为锚点标签并处理重复的问题
+export function mkdocsMaterialSlugify(text, existingSlugs = new Set()) {
+  // 参考 https://github.com/facelessuser/pymdown-extensions/blob/main/pymdownx/slugs.py
+  const slug = text
+    .normalize('NFC')
+    .trim()
+    .toLowerCase()
+    // 只保留数字、字母、重音符号、下划线、空格和 hyphen
+    .replace(/[^\p{L}\p{M}\p{N}_\- ]/gu, '')
+    // 将空格替换为 hyphen
+    .replace(/ /g, '-')
+
+  // 去重
+  let finalSlug = slug
+  let counter = 1
+  
+  while (existingSlugs.has(finalSlug)) {
+    finalSlug = `${slug}_${counter}`
+    counter++
+  }
+  
+  existingSlugs.add(finalSlug)
+  return finalSlug
 }

--- a/remark-typst/package.json
+++ b/remark-typst/package.json
@@ -9,6 +9,7 @@
     "to-vfile": "^8.0.0",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.0",
+    "mdast-util-to-string": "^4.0.0",
     "remark-mathjax": "file:./remark-mathjax",
     "escape-typst": "file:./escape-typst"
   },


### PR DESCRIPTION
closes https://github.com/OI-wiki/OI-wiki/issues/6480

本次 PR 主要实现了如下功能：
- **识别 Markdown 锚点**：允许识别形式为 `<a id="ref-id"></a>` 的 anchor，并在相应的文档里插入一个相应的 anchor
  - 实际使用的 regex 是 `/^<a\b[^>]*\bid="([^"]+)"[^>]*>$/u`，即要求字符串以 `<a ` 开始 `>` 结尾，且包含一个 `id` 字段，其中，`id` 字段必须以双引号包围
  - 尽管 regex 写得比较宽泛，预期标签的 id 字段应当和 slugify 的结果基本一致。对于 OI Wiki 的情形，基本上这相当于说，只包含汉字字符、小写英文字母、hyphen 和下划线
- **添加小节标题锚点**：将页面内所有等级的标题都插入一个相应的 anchor
  - 模拟了 mkdocs-material 的 slugify 的实现，把页面小节标题转换为 anchor id （含去重的部分）
- **生成锚点标签**：为了能够（使 latex）兼容这些 anchor 的标签，将所有标签文本用 JS 自带的 sha1 转成 hex 码然后截取前 16 个字符（计 64 个比特）
  - 在实际引用的时候，如果标签的首字母是 ascii，会导致标签后面的文字变成 percent-encoded，所以，索性把所有 unicode 文字都先转换为 percent-encoded（但保持 ascii 部分不变），然后再用 sha1 处理
  - 最后得到的锚点标签的实际格式为 `PageName-AnchorID`，这一格式有助于后文 typst 识别所在的 section
- **允许内链引用锚点**：改写了 internal link 部分，让它们能够把内链中页面内标签部分识别出来，并引到定义的 anchor 上
  - 改写了 `joinRelative` 的实现，允许识别裸 anchor 的情形，即 `[Something](#ref-id)`
  - 改写了 typst 编译的头文件关于引用的部分，允许用 `@ref-id[complement]` 格式引用任意位置锚点，并输出小节序号和引用所在页码
- **保证文档渲染效果**：对于只含有一个 anchor 的空段落：
  - typst 不添加段落标记，即 `#h(2em)`，否则 typst 会在 pdf 里添加一个空白行
  - latex 需要添加段落标记（即保持原状），否则 latex 会把 anchor 放到前一段落末尾

为查看实际效果，请参考 PDF 的如下章节：
- 简介 > 格式手册【列表内锚点】
- 简介 > 数学符号表【表格内锚点】
- 数学 > 数论 > 同余方程【Details 框前方锚点】
- 数学 > 数论 > 阶 & 原根【Details 框前方锚点、跨小节引用】