### PR TITLE
feat(*): support adding archive links to PDF.

### DIFF
--- a/.github/workflows/auto-release-typst.yml
+++ b/.github/workflows/auto-release-typst.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Download data.json
+        run: wget https://github.com/jyeric/OI-wiki/raw/refs/heads/archiveLink/data.json
+        working-directory: oi-wiki-export-typst
+
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,6 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download data.json
+        run: wget https://github.com/jyeric/OI-wiki/raw/refs/heads/archiveLink/data.json
+        working-directory: oi-wiki-export
+
       - name: Build the LaTeX document
         uses: xu-cheng/latex-action@v3
         with:

--- a/.github/workflows/test-build-typst.yml
+++ b/.github/workflows/test-build-typst.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Download data.json
+        run: wget https://github.com/jyeric/OI-wiki/raw/refs/heads/archiveLink/data.json
+        working-directory: oi-wiki-export-typst
       
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download data.json
+        run: wget https://github.com/jyeric/OI-wiki/raw/refs/heads/archiveLink/data.json
+        working-directory: oi-wiki-export
+      
       - name: Build the LaTeX document
         uses: xu-cheng/latex-action@v3
         with:

--- a/oi-wiki-export-typst/oi-wiki.typ
+++ b/oi-wiki-export-typst/oi-wiki.typ
@@ -153,20 +153,18 @@
   set text(9pt)
   set par(leading: .5em)
 
-  grid(columns: (
-      1fr,
-      1cm,
-      1fr,
-      1cm,
-      1fr,
-      1cm,
-    ), rows: 1cm, column-gutter: .2cm, row-gutter: .2cm, ..content)
+  // 每行只放一条参考：三列 -> [链接文本 | 二维码1 | 二维码2]
+  grid(
+    columns: (1fr, 1cm, 1cm),
+    align: (left + horizon, center + horizon, center + horizon),
+    column-gutter: .2cm,
+    row-gutter: .2cm,
+    ..content,
+  )
 }
-#let links-cell(content) = block(
-  width: 100%,
-  height: 100%,
-  align(horizon, content),
-)
+
+#let links-cell(content) = content
+
 #let qrcode(arg) = tiaoma.qrcode(arg, width: .9cm)
 
 #let tablex-custom(columns: (), aligns: (), ..cells) = {

--- a/oi-wiki-export/increase-mem-limit.py
+++ b/oi-wiki-export/increase-mem-limit.py
@@ -6,7 +6,7 @@ import subprocess
 config_file = subprocess.check_output(["kpsewhich", "texmf.cnf"]).decode().strip()
 
 memory_setting = "main_memory"
-new_value = "10000000"
+new_value = "12000000"
 
 output_lines = []
 with open(config_file, "r") as f:

--- a/remark-latex/lib/compiler.js
+++ b/remark-latex/lib/compiler.js
@@ -107,7 +107,7 @@ export default function compiler(options) {
           }
           let urlFormat = "";
           const originalUrl = url[i].replace(/\\/g, "");
-          const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["archiveLink"]
+          const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["shortArchiveLink"]
            if (archiveUrl != null) {
             urlFormat = `\\quad \\qrcode[height=1cm]{${url[i]}} \\quad \\quad \\qrcode[height=1cm]{${archiveUrl}}`;
           }

--- a/remark-latex/lib/compiler.js
+++ b/remark-latex/lib/compiler.js
@@ -2,7 +2,7 @@
 
 import { extname, join, dirname, basename } from "path";
 import { execFileSync } from "child_process";
-import { existsSync, writeFileSync, copyFileSync } from "fs";
+import { existsSync, writeFileSync, copyFileSync, readFileSync } from "fs";
 import { URL } from "url";
 
 import { visit } from "unist-util-visit";
@@ -37,6 +37,11 @@ if (!String.prototype.format) {
   };
 }
 
+//读取data.js，获取每个链接对应的archiveLink
+const archiveRawData = readFileSync("data.json", 'utf-8')
+const archiveData = JSON.parse(archiveRawData)
+
+
 export default function compiler(options) {
   const outLinkLable = new Map(); // 所有的外部链接，包括直接链接和引用式链接，键-值：链接-链接label
   let hasFootnote = false; // 判断之前有没有footnote
@@ -69,6 +74,7 @@ export default function compiler(options) {
     if (footnoteCount > 0) {
       if (hasFootnote === false) {
         article += "\n\\subsubsection{参考资料与注释}";
+        article += "\n\\begin{flushright}\n原链接 \\quad 存档链接\n\\end{flushright}"
       }
       article += "\n\\begin{enumerate}\n";
       for (let id = 1; id <= footnoteCount; ++id) {
@@ -99,7 +105,16 @@ export default function compiler(options) {
           ) {
             url[i] = encodeURI(url[i]);
           }
-          const urlFormat = `\\quad \\qrcode[height=1cm]{${url[i]}}`;
+          let urlFormat = "";
+          const originalUrl = url[i].replace(/\\/g, "");
+          const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["archiveLink"]
+           if (archiveUrl != null) {
+            urlFormat = `\\quad \\qrcode[height=1cm]{${url[i]}} \\quad \\quad \\qrcode[height=1cm]{${archiveUrl}}`;
+          }
+          else {
+            urlFormat = `\\quad \\qrcode[height=1cm]{${url[i]}}`;
+            console.log(`Unarchive: ${originalUrl}`);
+          }
           article += urlFormat;
         }
         article += "\n";

--- a/remark-typst/lib/compiler.js
+++ b/remark-typst/lib/compiler.js
@@ -2,7 +2,7 @@
 
 import { extname, join, dirname, basename } from 'path'
 import { execFileSync, spawnSync } from 'child_process'
-import { existsSync, writeFileSync, copyFileSync } from 'fs'
+import { existsSync, writeFileSync, copyFileSync, readFileSync } from 'fs'
 import { URL } from 'url'
 
 import { visit } from 'unist-util-visit'
@@ -17,6 +17,10 @@ import {
 import escape from '../escape-typst/src/index.js'
 // MathJax SVG export
 import { renderSvg } from '../remark-mathjax/svg.js'
+
+// 读取存档链接
+const archiveRawData = readFileSync("data.json", 'utf-8')
+const archiveData = JSON.parse(archiveRawData)
 
 // 给 String 添加 format 方法，方便格式化输出
 if (!String.prototype.format) {
@@ -86,10 +90,23 @@ function toTypst(tree, options) {
 
     article += '#links-grid('
     for (const [i, link] of arrayLinks.entries()) {
-      article += 'links-cell[#text(fill: cmyk(0%, 100%, 100%, 0%))[\\[{0}\\]] #link("{1}")[{2}]], qrcode("{1}"), \n'.format(
-        i + 1,
-        link.location.replace(/\\/g, '\\\\'),
-        link.plainText)
+      const originalUrl = link.location.replace(/\\/g, "")
+      const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["archiveLink"]
+      if (archiveUrl != null) {
+        article += 'links-cell[#text(fill: cmyk(0%, 100%, 100%, 0%))[\\[{0}\\]] #link("{1}")[{2}]], qrcode("{1}"), qrcode("{3}"), \n'.format(
+          i + 1,
+          link.location.replace(/\\/g, '\\\\'),
+          link.plainText,
+          archiveUrl)
+      }
+      else {
+        article += 'links-cell[#text(fill: cmyk(0%, 100%, 100%, 0%))[\\[{0}\\]] #link("{1}")[{2}]], qrcode("{1}"), block(width: .9cm, height: .9cm)[], \n'.format(
+          i + 1,
+          link.location.replace(/\\/g, '\\\\'),
+          link.plainText)
+        console.log(`Unarchive: ${originalUrl}`)
+      }
+      
     }
     article += ')\n'
   }

--- a/remark-typst/lib/compiler.js
+++ b/remark-typst/lib/compiler.js
@@ -91,7 +91,7 @@ function toTypst(tree, options) {
     article += '#links-grid('
     for (const [i, link] of arrayLinks.entries()) {
       const originalUrl = link.location.replace(/\\/g, "")
-      const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["archiveLink"]
+      const archiveUrl = archiveData[originalUrl] && archiveData[originalUrl]["shortArchiveLink"]
       if (archiveUrl != null) {
         article += 'links-cell[#text(fill: cmyk(0%, 100%, 100%, 0%))[\\[{0}\\]] #link("{1}")[{2}]], qrcode("{1}"), qrcode("{3}"), \n'.format(
           i + 1,


### PR DESCRIPTION
本次 PR 主要实现了将存档链接到PDF当中。（合并需等待存档链接data.json合并入OI-wiki仓库后，修改文件中仓库地址）

相较于原来版本。在LaTex中的参考链接二维码后添加了存档链接二维码。Typst将一行多个链接修改为参考LaTex的一行一个链接。

效果如图：
 - LaTex版本：
<img width="1090" height="264" alt="image" src="https://github.com/user-attachments/assets/db8ad3d3-83af-47b5-bc23-05f7dc0855a5" />
 - Typst版本：
<img width="1377" height="746" alt="image" src="https://github.com/user-attachments/assets/c9845ce3-4c6f-4772-a6f3-56d647daac8e" />

具体PDF可以参考下载artifacts：
 - LaTex版本：https://github.com/jyeric/OI-Wiki-export/actions/runs/18077717437
 - Typst版本：https://github.com/jyeric/OI-Wiki-export/actions/runs/18077717428