### PR TITLE
fix(*): support scalar MkDocs tags and flat nav entries

### DIFF
--- a/oi-wiki-export-typst/index.js
+++ b/oi-wiki-export-typst/index.js
@@ -10,7 +10,7 @@ import remarkDetails from 'remark-details'
 import remarkGfm from 'remark-gfm'
 import remarkTabbed from 'remark-tabbed'
 import { read, writeSync } from 'to-vfile'
-import { Type, Schema, load } from 'js-yaml'
+import { Type, DEFAULT_SCHEMA, load } from 'js-yaml'
 
 import _snippet from '../remark-snippet/index.js'
 import remarkTypst from '../remark-typst/index.js'
@@ -67,15 +67,16 @@ async function main() {
   const yamlFileContent = await fs.readFile(yamlFile, 'utf8');
 
   // fix YAMLException: unknown tag
-  const types = yamlFileContent
-    .match(/!!python\/name:.*/g)
-    .map(s => new Type(s.replace('!!', 'tag:yaml.org,2002:'), {
-      kind: 'mapping',
-      construct: function (data) {
-        return data
-      }
-    }))
-  const configSchema = new Schema(types)
+  const pythonNameTags = [
+    ...new Set(yamlFileContent.match(/!!python\/name:[^\s]+/g) ?? [])
+  ]
+  const types = pythonNameTags.map(s => new Type(s.replace('!!', 'tag:yaml.org,2002:'), {
+    kind: 'scalar',
+    construct: function (data) {
+      return data
+    }
+  }))
+  const configSchema = DEFAULT_SCHEMA.extend(types)
 
   const config = load(yamlFileContent, { schema: configSchema })
   const catalog = config.nav // 文档目录
@@ -134,6 +135,20 @@ async function main() {
     let result = ''
     depth = Math.min(depth, 6)
 
+    if (typeof object === 'string') {
+      await convertMarkdown(join(oiwikiRoot, 'docs', object), depth, object)
+
+      const moduleName = escape(getModuleName(object))
+      return '#include "' + moduleName + '.typ"\n'
+    }
+
+    if (object instanceof Array) {
+      for (const item of object) {
+        result += await exportRecursive(item, depth)
+      }
+      return result
+    }
+
     for (const key in object) {
       console.log(INFO + 'Exporting: ' + key)
 
@@ -177,16 +192,12 @@ async function main() {
 
   function getLabel(obj) {  
     if (obj instanceof Array) {
-      let idx = 0
-      let label = ''
-      while (true) {
-        label = getLabel(obj[idx])
+      for (const item of obj) {
+        const label = getLabel(item)
         if (label !== '')
-          break
-
-        ++idx
+          return label
       }
-      return label
+      return ''
     }
 
     if (obj instanceof Object) {

--- a/oi-wiki-export/index.js
+++ b/oi-wiki-export/index.js
@@ -8,7 +8,7 @@ import remarkGfm from "remark-gfm";
 import { latex } from "remark-latex";
 import remarkFootnotes from "remark-footnotes";
 import { read, writeSync } from "to-vfile";
-import { Type, Schema, load } from "js-yaml";
+import { Type, DEFAULT_SCHEMA, load } from "js-yaml";
 import { join } from "path";
 import { promises as fs } from "fs";
 import snippet from "../remark-snippet/index.js";
@@ -59,16 +59,19 @@ async function main() {
   const yamlFileContent = await fs.readFile(yamlFile, "utf8");
 
   // fix YAMLException: unknown tag
-  const types = yamlFileContent.match(/!!python\/name:.*/g).map(
+  const pythonNameTags = [
+    ...new Set(yamlFileContent.match(/!!python\/name:[^\s]+/g) ?? []),
+  ];
+  const types = pythonNameTags.map(
     (s) =>
       new Type(s.replace("!!", "tag:yaml.org,2002:"), {
-        kind: "mapping",
+        kind: "scalar",
         construct: function (data) {
           return data;
         },
       })
   );
-  const CONFIG_SCHEMA = new Schema(types);
+  const CONFIG_SCHEMA = DEFAULT_SCHEMA.extend(types);
 
   const config = load(yamlFileContent, { schema: CONFIG_SCHEMA });
   const catalog = config.nav; // 文档目录
@@ -136,6 +139,19 @@ async function main() {
     ]; // 各层次对应的 TeX 命令
     let result = "";
     depth = Math.min(depth, block.length);
+
+    if (typeof object === "string") {
+      await convertMarkdown(join(oiwikiRoot, "docs", object), depth);
+      return "\\input{" + escape(getTexModuleName(object)) + "}\n";
+    }
+
+    if (object instanceof Array) {
+      for (const item of object) {
+        result += await exportRecursive(item, depth);
+      }
+      return result;
+    }
+
     for (const key in object) {
       console.log("[Info] Exporting: " + key);
       result += "\\" + block[depth] + "{" + escape(key) + "}\n";


### PR DESCRIPTION
Some MkDocs Material configurations use Python object tags as scalar values, for example `!!python/name:materialx.emoji.twemoji`. The previous schema compatibility code captured the whole line and registered the tag as a mapping, which made js-yaml fail before the exporter could read the nav tree.

MkDocs also allows nav arrays to contain bare markdown paths instead of only title-to-path mappings. For example, this is valid MkDocs syntax:

```yaml
nav:
  - Start:
    - index.md
    - usage.md
    - Guide:
      - contribute/before-contributing.md
```

The array node is only an ordered container, and the string nodes are pages. The previous exporters treated array indexes as headings and could then iterate a string path character-by-character.

Extend the discovered `!!python/name:*` tags from the default YAML schema as scalar constructors in both exporters. Also teach the LaTeX and Typst nav walkers to handle string nodes as pages and array nodes as ordered containers, while keeping existing mapping behavior unchanged. The Typst label helper now safely returns an empty label when an array contains no label-bearing child.

Validation: node --check oi-wiki-export/index.js; node --check oi-wiki-export-typst/index.js