### PR TITLE
fix(remark-typst): emit tuple aligns for tables

### DIFF
--- a/remark-typst/lib/compiler.js
+++ b/remark-typst/lib/compiler.js
@@ -326,7 +326,7 @@ function toTypst(tree, options) {
         const header = parse(node.children[0])
         inTableHeader = false
 
-        return '#tablex-custom(columns: {0}, aligns: ({1}), {2}{3})'.format(
+        return '#tablex-custom(columns: {0}, aligns: ({1},), {2}{3})'.format(
           node.align.length,
           node.align.map(s => s || 'left').join(', '),
           header,


### PR DESCRIPTION
The Typst template passes table alignments to `tablex-custom`, which later indexes them with `aligns.at(col)`. For multi-column tables the generated `aligns: (left, center)` value is an array-like tuple, but for one-column tables `aligns: (center)` is just the parenthesized alignment value itself.

A one-column Markdown table is enough to trigger this shape mismatch, for example:

```markdown
| Constant |
| :------: |
| 0x3c6ef372 |
```

That table previously generated `aligns: (center)`, and compiling the resulting Typst could fail with `type alignment has no method at`.

Always emit a trailing comma in the generated alignment tuple. Typst accepts the trailing comma for any number of columns, and it preserves tuple shape for the one-column case: `aligns: (center,)`.

Validation: node --check remark-typst/lib/compiler.js; converted a one-column centered Markdown table and confirmed the output contains `aligns: (center,)`.