### PR TITLE
fix(*): preserve image URL case

### DIFF
--- a/remark-latex/lib/compiler.js
+++ b/remark-latex/lib/compiler.js
@@ -276,14 +276,15 @@ export default function compiler(options) {
         } else {
           ext = extname(loc);
         }
-        const is_svg = ext === ".svg";
+        const normalizedExt = ext.toLowerCase();
+        const is_svg = normalizedExt === ".svg";
         dest = join(
           "images",
           toPrefix(join(dirname(uri), basename(uri, extname(uri)))) +
             (is_svg ? ".pdf" : ".jpg")
         );
         // convert
-        switch (ext) {
+        switch (normalizedExt) {
           case ".jpg":
           case ".jpeg": {
             if (!existsSync(dest)) {
@@ -316,7 +317,7 @@ export default function compiler(options) {
             if (!existsSync(dest)) {
               // 混合白色背景（原图可能是 PNG 透明图）
               execFileSync("magick", [
-                ext === ".gif" ? uri + "[0]" : uri,
+                normalizedExt === ".gif" ? uri + "[0]" : uri,
                 "-background",
                 "white",
                 "-flatten",
@@ -483,7 +484,7 @@ export default function compiler(options) {
         return "";
       }
       case "image": {
-        return makeImage(node.url.toLowerCase());
+        return makeImage(node.url);
       }
       case "imageReference": {
         if (links[node.identifier]) {

--- a/remark-typst/lib/compiler.js
+++ b/remark-typst/lib/compiler.js
@@ -152,10 +152,11 @@ function toTypst(tree, options) {
         } else {
           ext = extname(loc)
         }
-        const is_svg = ext === '.svg'
+        const normalizedExt = ext.toLowerCase()
+        const is_svg = normalizedExt === '.svg'
         dest = join('images', toPrefix(join(dirname(uri), basename(uri, extname(uri)))) + (is_svg ? '.svg' : '.jpg'))
         // convert
-        switch (ext) {
+        switch (normalizedExt) {
           case '.jpg':
           case '.svg': {
             if (!existsSync(dest)) {
@@ -174,7 +175,7 @@ function toTypst(tree, options) {
               // 混合白色背景（原图可能是 PNG 透明图）
               execFileSync(
                 'convert',
-                ['-background', 'white', '-flatten', ext === '.gif' ? uri + '[0]' : uri, dest])
+                ['-background', 'white', '-flatten', normalizedExt === '.gif' ? uri + '[0]' : uri, dest])
             }
             break
           }
@@ -304,7 +305,7 @@ function toTypst(tree, options) {
         if (parsingPlain) {
           return node.title || node.alt || node.url
         }
-        return makeImage(node.url.toLowerCase())
+        return makeImage(node.url)
       }
       case 'imageReference': {
         const defn = mapDefinitions.get(node.identifier)


### PR DESCRIPTION
Normal image nodes were lowercased before they were passed into makeImage. I don't know why they are lowered in the old days, and the neighboring image-reference code path in both compilers already passes the stored URL through unchanged.

That lowercasing is observable for remote images with case-sensitive paths. For example, `![Alt](http://127.0.0.1:8080/Assets/Upper.JPG)` used to request /assets/upper.jpg, which can 404 even though /Assets/Upper.JPG exists.

Keep the original image URL when resolving or downloading the source image, and normalize only the extracted extension for converter dispatch. That preserves the existing .JPG/.SVG/.GIF type handling without rewriting the URL itself.

Apply the same fix to the LaTeX and Typst compilers so the two export paths stay consistent.

Validation:
- node --check remark-latex/lib/compiler.js
- node --check remark-typst/lib/compiler.js
- Ran a local HTTP-server sample through remark-typst and observed the request path /Assets/Upper.JPG